### PR TITLE
Fix CSS variable syntax and improve HTML accessibility in resume and …

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -23,7 +23,7 @@ const filteredHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 3);
         <li class:list={[heading.depth === 3 && 'ml-4']}>
           <a 
             href={`#${heading.slug}`}
-            class="toc-link block py-1 transition-colors hover:text-[var(--gradient-start)]"
+            class="toc-link block py-1 transition-colors hover:text-(--gradient-start)"
             style="color: var(--text-secondary);"
             data-slug={heading.slug}
           >
@@ -74,4 +74,5 @@ const filteredHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 3);
     font-weight: 500;
   }
 </style>
+
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -32,7 +32,7 @@ import SocialLinks from '@/components/SocialLinks.astro';
               </div>
               <div>
                 <p class="text-sm" style="color: var(--text-tertiary);">Email</p>
-                <a href="mailto:contact@danieldieppa.dev" class="font-medium hover:text-[var(--gradient-start)]">
+                <a href="mailto:contact@danieldieppa.dev" class="font-medium hover:text-(--gradient-start)">
                   contact@danieldieppa.dev
                 </a>
               </div>
@@ -82,7 +82,7 @@ import SocialLinks from '@/components/SocialLinks.astro';
               id="name" 
               name="name"
               required
-              class="w-full px-4 py-2.5 rounded-lg border outline-none transition-colors focus:border-[var(--gradient-start)]"
+              class="w-full px-4 py-2.5 rounded-lg border outline-none transition-colors focus:border-(--gradient-start)"
               style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);"
               placeholder="Your name"
             />
@@ -95,7 +95,7 @@ import SocialLinks from '@/components/SocialLinks.astro';
               id="email" 
               name="email"
               required
-              class="w-full px-4 py-2.5 rounded-lg border outline-none transition-colors focus:border-[var(--gradient-start)]"
+              class="w-full px-4 py-2.5 rounded-lg border outline-none transition-colors focus:border-(--gradient-start)"
               style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);"
               placeholder="your@email.com"
             />
@@ -108,7 +108,7 @@ import SocialLinks from '@/components/SocialLinks.astro';
               id="subject" 
               name="subject"
               required
-              class="w-full px-4 py-2.5 rounded-lg border outline-none transition-colors focus:border-[var(--gradient-start)]"
+              class="w-full px-4 py-2.5 rounded-lg border outline-none transition-colors focus:border-(--gradient-start)"
               style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);"
               placeholder="What's this about?"
             />
@@ -121,7 +121,7 @@ import SocialLinks from '@/components/SocialLinks.astro';
               name="message"
               required
               rows="5"
-              class="w-full px-4 py-2.5 rounded-lg border outline-none transition-colors focus:border-[var(--gradient-start)] resize-none"
+              class="w-full px-4 py-2.5 rounded-lg border outline-none transition-colors focus:border-(--gradient-start) resize-none"
               style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);"
               placeholder="Your message..."
             ></textarea>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -103,8 +103,8 @@ const resumeHeadings = [
       <!-- Main Content -->
       <div class="space-y-12">
         <!-- Experience -->
-        <section id="work-experience" class="scroll-mt-24">
-      <h2 class="text-2xl font-bold mb-6 pb-2 border-b" style="border-color: var(--border-color);">
+        <section class="scroll-mt-24" aria-labelledby="work-experience">
+      <h2 id="work-experience" class="text-2xl font-bold mb-6 pb-2 border-b" style="border-color: var(--border-color);">
         Work Experience
       </h2>
       <div class="space-y-8">
@@ -123,7 +123,7 @@ const resumeHeadings = [
             <ul class="space-y-1.5">
               {exp.highlights.map(highlight => (
                 <li class="flex items-start gap-2 text-sm" style="color: var(--text-secondary);">
-                  <svg class="w-4 h-4 mt-0.5 flex-shrink-0" style="color: var(--gradient-start);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <svg class="w-4 h-4 mt-0.5 shrink-0" style="color: var(--gradient-start);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
                   </svg>
                   {highlight}
@@ -136,8 +136,8 @@ const resumeHeadings = [
     </section>
     
         <!-- Skills -->
-        <section id="technical-skills" class="scroll-mt-24">
-      <h2 class="text-2xl font-bold mb-6 pb-2 border-b" style="border-color: var(--border-color);">
+        <section class="scroll-mt-24" aria-labelledby="technical-skills">
+      <h2 id="technical-skills" class="text-2xl font-bold mb-6 pb-2 border-b" style="border-color: var(--border-color);">
         Technical Skills
       </h2>
       <div class="space-y-6">
@@ -157,14 +157,14 @@ const resumeHeadings = [
     </section>
     
         <!-- Soft Skills -->
-        <section id="soft-skills" class="scroll-mt-24">
-      <h2 class="text-2xl font-bold mb-6 pb-2 border-b" style="border-color: var(--border-color);">
+        <section class="scroll-mt-24" aria-labelledby="soft-skills">
+      <h2 id="soft-skills" class="text-2xl font-bold mb-6 pb-2 border-b" style="border-color: var(--border-color);">
         Soft Skills
       </h2>
       <div class="grid gap-3 sm:grid-cols-2">
         {softSkills.map(skill => (
           <div class="flex items-center gap-3 p-3 rounded-lg" style="background-color: var(--bg-secondary);">
-            <svg class="w-5 h-5 flex-shrink-0" style="color: var(--gradient-start);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <svg class="w-5 h-5 shrink-0" style="color: var(--gradient-start);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <span style="color: var(--text-secondary);">{skill}</span>
@@ -174,8 +174,8 @@ const resumeHeadings = [
     </section>
     
         <!-- Education -->
-        <section id="education" class="scroll-mt-24">
-      <h2 class="text-2xl font-bold mb-6 pb-2 border-b" style="border-color: var(--border-color);">
+        <section class="scroll-mt-24" aria-labelledby="education">
+      <h2 id="education" class="text-2xl font-bold mb-6 pb-2 border-b" style="border-color: var(--border-color);">
         Education
       </h2>
       <div class="p-5 rounded-xl border" style="background-color: var(--card-bg); border-color: var(--border-color);">
@@ -185,8 +185,8 @@ const resumeHeadings = [
     </section>
     
         <!-- Languages -->
-        <section id="languages" class="scroll-mt-24">
-      <h2 class="text-2xl font-bold mb-6 pb-2 border-b" style="border-color: var(--border-color);">
+        <section class="scroll-mt-24" aria-labelledby="languages">
+      <h2 id="languages" class="text-2xl font-bold mb-6 pb-2 border-b" style="border-color: var(--border-color);">
         Languages
       </h2>
       <div class="flex gap-4">
@@ -211,4 +211,5 @@ const resumeHeadings = [
     </div>
   </article>
 </BaseLayout>
+
 

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -29,7 +29,7 @@ const { tag, posts } = Astro.props;
     <header class="mb-10">
       <a 
         href="/tags" 
-        class="inline-flex items-center gap-1 text-sm mb-4 transition-colors hover:text-[var(--gradient-start)]"
+        class="inline-flex items-center gap-1 text-sm mb-4 transition-colors hover:text-(--gradient-start)"
         style="color: var(--text-secondary);"
       >
         <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -34,7 +34,7 @@ const sortedTags = Object.entries(tagCounts)
           class="group px-4 py-2 rounded-xl border transition-all hover:scale-105 hover:shadow-md"
           style="background-color: var(--card-bg); border-color: var(--border-color);"
         >
-          <span class="font-medium group-hover:text-[var(--gradient-start)] transition-colors">#{tag}</span>
+          <span class="font-medium group-hover:text-(--gradient-start) transition-colors">#{tag}</span>
           <span class="ml-2 text-sm px-2 py-0.5 rounded-full" style="background-color: var(--bg-tertiary); color: var(--text-tertiary);">
             {count}
           </span>


### PR DESCRIPTION
…form components

- Replace incorrect `text-[var(--gradient-start)]` and `border-[var(--gradient-start)]` with `text-(--gradient-start)` and `border-(--gradient-start)` syntax in TableOfContents, contact form inputs, and tags page.
- Move section IDs from section elements to heading elements for proper anchor linking in resume page.
- Add `aria-labelledby` attributes to resume sections for better accessibility.
- Replace `flex-shrink-0` with `